### PR TITLE
refactor prop-types for latest react version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactNative = require('react-native');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -90,11 +94,11 @@ var Hr = function (_Component) {
 }(_react.Component);
 
 Hr.propTypes = {
-    lineStyle: _react.PropTypes.shape({}),
-    text: _react.PropTypes.string,
-    marginLeft: _react.PropTypes.number,
-    marginRight: _react.PropTypes.number,
-    textStyle: _react.PropTypes.shape({})
+    lineStyle: _propTypes2.default.shape({}),
+    text: _propTypes2.default.string,
+    marginLeft: _propTypes2.default.number,
+    marginRight: _propTypes2.default.number,
+    textStyle: _propTypes2.default.shape({})
 };
 
 Hr.defaultProps = {

--- a/examples/hr.dist.js
+++ b/examples/hr.dist.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactNative = require('react-native');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -90,11 +94,11 @@ var Hr = function (_Component) {
 }(_react.Component);
 
 Hr.propTypes = {
-    lineStyle: _react.PropTypes.shape({}),
-    text: _react.PropTypes.string,
-    marginLeft: _react.PropTypes.number,
-    marginRight: _react.PropTypes.number,
-    textStyle: _react.PropTypes.shape({})
+    lineStyle: _propTypes2.default.shape({}),
+    text: _propTypes2.default.string,
+    marginLeft: _propTypes2.default.number,
+    marginRight: _propTypes2.default.number,
+    textStyle: _propTypes2.default.shape({})
 };
 
 Hr.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-rename": "^1.2.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
     StyleSheet,
     Text,


### PR DESCRIPTION
React has factored prop-types out of the main react object, which means the hr tool errors out on the latest react version.  

I believe this pr will fix it. 