### PR TITLE
Rebuild dist so it doesn't use react.PropTypes (deprecated)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactNative = require('react-native');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -90,11 +94,11 @@ var Hr = function (_Component) {
 }(_react.Component);
 
 Hr.propTypes = {
-    lineStyle: _react.PropTypes.shape({}),
-    text: _react.PropTypes.string,
-    marginLeft: _react.PropTypes.number,
-    marginRight: _react.PropTypes.number,
-    textStyle: _react.PropTypes.shape({})
+    lineStyle: _propTypes2.default.shape({}),
+    text: _propTypes2.default.string,
+    marginLeft: _propTypes2.default.number,
+    marginRight: _propTypes2.default.number,
+    textStyle: _propTypes2.default.shape({})
 };
 
 Hr.defaultProps = {

--- a/examples/hr.dist.js
+++ b/examples/hr.dist.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactNative = require('react-native');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -90,11 +94,11 @@ var Hr = function (_Component) {
 }(_react.Component);
 
 Hr.propTypes = {
-    lineStyle: _react.PropTypes.shape({}),
-    text: _react.PropTypes.string,
-    marginLeft: _react.PropTypes.number,
-    marginRight: _react.PropTypes.number,
-    textStyle: _react.PropTypes.shape({})
+    lineStyle: _propTypes2.default.shape({}),
+    text: _propTypes2.default.string,
+    marginLeft: _propTypes2.default.number,
+    marginRight: _propTypes2.default.number,
+    textStyle: _propTypes2.default.shape({})
 };
 
 Hr.defaultProps = {


### PR DESCRIPTION
I was getting a "Cannot read property shape of undefined" error

I tracked it down to `_react.PropTypes` not being defined since `react.PropTypes` is deprecated in `dist/index.js`

This pr basically rebuilds `dist` so that PropTypes is sourced from `prop-types` instead of from `react`